### PR TITLE
export the lambda function name

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -61,3 +61,9 @@ Outputs:
   CloudFrontInvalidatorRoleArn:
     Description: "CloudFront Invalidator Role used for Lambda function"
     Value: !GetAtt CloudFrontInvalidatorRole.Arn
+  CloudFrontInvalidatorFunctionName:
+    # used when bringing pipelines up via CloudFormation - https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-Lambda.html#action-reference-Lambda-config
+    Description: "Lambda Function Name"
+    Value: !Ref CloudFrontInvalidatorFunction
+    Export:
+      Name: !Sub "${AWS::StackName}-CloudFrontInvalidatorFunctionName"


### PR DESCRIPTION
If you're bringing up a pipeline via CloudFormation, you'll need to use the function name rather than the ARN.  This adds an export that those stacks can use.